### PR TITLE
Rewording of README and docblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(mixed $reason, mixed $value) <`$reason` shall be `null` on success, `$value` shall be `null` on failure>
+     * @param callable(mixed $reason, mixed $value) @onResolved `$reason` shall be `null` on success, `$value` shall be
+     *     `null` on failure.
      *
      * @return void
      */

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ interface Promise
 
 The implementation MAY extend `Promise::when` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
 
-All callbacks registered before the resolution MUST be executed in the order they were registered. Callbacks registered after the resolution MUST be executed immediately. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `Interop\Async\Promise\ErrorHandler::notify`. The `Promise` MUST then continue to call the remaining callbacks with the original parameters.
-
 All callbacks registered before the resolution MUST be executed in the order they were registered. Callbacks registered after the resolution MUST be executed immediately. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
 Registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ interface Promise
 }
 ```
 
-The implementation MAY extend `Promise::when` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
+The implementation MAY extend `Promise::when()` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
 
 All callbacks registered before the `Promise` is resolved MUST be executed in the order they were registered after the `Promise` has been resolved. Callbacks registered after the resolution MUST be executed immediately.
 

--- a/README.md
+++ b/README.md
@@ -56,20 +56,18 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(mixed $reason, mixed $value) @onResolved `$reason` shall be `null` on success, `$value` shall be
-     *     `null` on failure.
+     * @param callable(\Throwable|\Exception|null $exception, mixed $value) @onResolved `$reason` shall be `null` on
+     *     success, `$value` shall be `null` on failure.
      *
-     * @return void
+     * @return mixed Return type and value are unspecified.
      */
     public function when(callable $onResolved);
 }
 ```
 
-The implementation MAY extend `Promise::when()` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
-
 All callbacks registered before the `Promise` is resolved MUST be executed in the order they were registered after the `Promise` has been resolved. Callbacks registered after the resolution MUST be executed immediately.
 
-If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
+The invocation of `Promise::when()` MUST NOT throw exceptions bubbling up from a `$onResolved` invocation. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
 
 Registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Promise
 
-The purpose of this specification is to provide a common interface for simple placeholder objects returned from async operations. This allows libraries and components from different vendors to create coroutines regardless of the used placeholder implementation. This specification is not designed to replace promise implementations that may be chained. Instead, this interface may be extended by promise implementations.
+The purpose of this specification is to provide a common interface for simple placeholder objects returned from async operations. This allows libraries and components from different vendors to create coroutines regardless of the placeholder implementation used. This specification is not designed to replace promise implementations that may be chained. Instead, the common interface may be extended by promise implementations.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].
 
-A `Promise` represents the eventual result of an asynchronous operation. Interaction with a `Promise` happens through its `when()` method, which registers a callback to receive either a `Promise`'s eventual value or the reason why the `Promise` has failed.
+A `Promise` represents the eventual result of an asynchronous operation. Interaction with a `Promise` happens through its `when()` method, which registers a callback to receive either a `Promise`'s eventual value, or reason for failure.
 
 `Promise` is the fundamental primitive in asynchronous programming. It should be as lightweight as possible, as any cost adds up significantly.
 
-This specification defines the absolute minimums for interoperable coroutines, which can be implemented in PHP using generators.
+This specification defines the absolute minimum for interoperable coroutines, which can be implemented in PHP using generators.
 
-This specification does not deal with how to create, succeed or fail `Promise`s, as only the consumption of `Promise`s is required to be interoperable.
+This specification does not deal with how a `Promise` should be created, succeed, or fail, as only the consumption of `Promise` is required to be interoperable.
 
 For further design explanations and notes, please refer to [the meta document](META.md).
 
@@ -39,7 +39,7 @@ A `Promise` is resolved once it either succeeded or failed.
 
 ## Consumption
 
-A `Promise` MUST implement `AsyncInterop\Promise` and thus provide a `when()` method to access its current or eventual value or reason.
+A `Promise` MUST implement `AsyncInterop\Promise` and thus provide a `when()` method to access its value or reason.
 
 ```php
 <?php
@@ -54,14 +54,9 @@ interface Promise
     /**
      * Registers a callback to be invoked when the promise is resolved.
      *
-     * The callback receives `null` as first parameter and `$value` as second parameter on success. It receives the
-     * failure reason as first parameter and `null` as second parameter on failure.
-     *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * Warning: If you use type declarations for `$value`, be sure to make them accept `null` in case of failures.
-     *
-     * @param callable(\Throwable|\Exception|null $exception, mixed $value) $onResolved Callback to be executed.
+     * @param callable(mixed $reason, mixed $value) <`$reason` shall be `null` on success, `$value` shall be `null` on failure>
      *
      * @return void
      */
@@ -69,20 +64,11 @@ interface Promise
 }
 ```
 
-The `when()` method MUST accept at least one argument:
+The implementation MAY extend `Promise::when` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
 
-`$callback` – A callable conforming to the following signature:
-
-```php
-function($error, $value) { /* ... */ }
-```
-
-Any implementation MUST at least provide these two parameters. The implementation MAY extend the `Promise` interface with additional parameters passed to the callback. Further arguments to `when()` MUST have default values, so `when()` can always be called with only one argument. `when()` MAY NOT return a value. `when()` MUST NOT throw exceptions bubbling up from a callback invocation.
-
-> **NOTE:** The signature doesn't specify a type for `$error`. This is due to the new `Throwable` interface introduced in PHP 7. As this specification is PHP 5 compatible, we can use neither `Throwable` nor `Exception`.
+All callbacks registered before the resolution MUST be executed in the order they were registered. Callbacks registered after the resolution MUST be executed immediately. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `Interop\Async\Promise\ErrorHandler::notify`. The `Promise` MUST then continue to call the remaining callbacks with the original parameters.
 
 All callbacks registered before the resolution MUST be executed in the order they were registered. Callbacks registered after the resolution MUST be executed immediately. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
-
 Registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ interface Promise
 
 The implementation MAY extend `Promise::when` with additional parameters passed to the callback. Further arguments to `Promise::when()` MUST have default values, so `Promise::when()` can always be called with only one argument. `Promise::when()` MAY NOT return a value. `Promise::when()` MUST NOT throw exceptions bubbling up from a callback invocation.
 
-All callbacks registered before the resolution MUST be executed in the order they were registered. Callbacks registered after the resolution MUST be executed immediately. If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
+All callbacks registered before the `Promise` is resolved MUST be executed in the order they were registered after the `Promise` has been resolved. Callbacks registered after the resolution MUST be executed immediately.
+
+If one of the callbacks throws an `Exception` or `Throwable`, it MUST be forwarded to `AsyncInterop\Promise\ErrorHandler::notify`. The `Promise` implementation MUST then continue to call the remaining callbacks with the original parameters.
+
 Registered callbacks MUST NOT be called from a file with strict types enabled (`declare(strict_types=1)`).
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(\Throwable|\Exception|null $exception, mixed $value) @onResolved `$reason` shall be `null` on
+     * @param callable(\Throwable|\Exception|null $exception, $value) @onResolved `$reason` shall be `null` on
      *     success, `$value` shall be `null` on failure.
      *
      * @return mixed Return type and value are unspecified.

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,7 +12,7 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(\Throwable|\Exception|null $exception, mixed $value) @onResolved `$reason` shall be `null` on
+     * @param callable(\Throwable|\Exception|null $exception, $value) @onResolved `$reason` shall be `null` on
      *     success, `$value` shall be `null` on failure.
      *
      * @return mixed Return type and value are unspecified.

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,7 +12,8 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(mixed $reason, mixed $value) <`$reason` shall be `null` on success, `$value` shall be `null` on failure>
+     * @param callable(mixed $reason, mixed $value) @onResolved `$reason` shall be `null` on success, `$value` shall be
+     *     `null` on failure.
      *
      * @return void
      */

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,10 +12,10 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(mixed $reason, mixed $value) @onResolved `$reason` shall be `null` on success, `$value` shall be
-     *     `null` on failure.
+     * @param callable(\Throwable|\Exception|null $exception, mixed $value) @onResolved `$reason` shall be `null` on
+     *     success, `$value` shall be `null` on failure.
      *
-     * @return void
+     * @return mixed Return type and value are unspecified.
      */
     public function when(callable $onResolved);
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -10,14 +10,9 @@ interface Promise
     /**
      * Registers a callback to be invoked when the promise is resolved.
      *
-     * The callback receives `null` as first parameter and `$value` as second parameter on success. It receives the
-     * failure reason as first parameter and `null` as second parameter on failure.
-     *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * Warning: If you use type declarations for `$value`, be sure to make them accept `null` in case of failures.
-     *
-     * @param callable(\Throwable|\Exception|null $exception, mixed $value) $onResolved Callback to be executed.
+     * @param callable(mixed $reason, mixed $value) <`$reason` shall be `null` on success, `$value` shall be `null` on failure>
      *
      * @return void
      */


### PR DESCRIPTION
This PR supercedes #34. It additionally formats `@param` as in async-interop/event-loop.