### PR TITLE
Use register_shutdown_function for panic

### DIFF
--- a/test/phpt/error_handler_007.phpt
+++ b/test/phpt/error_handler_007.phpt
@@ -30,5 +30,17 @@ set_error_handler(function () {
 AsyncInterop\Promise\ErrorHandler::notify(new Exception);
 
 ?>
---EXPECT--
-Fatal error: Uncaught exception 'RuntimeException' while trying to report a throwing AsyncInterop\Promise::when() handler gracefully.
+--EXPECTF--
+%SRuntimeException%S
+Stack trace:
+#0 %s
+#1 %s
+#2 %s
+#3 %s
+#4 %s
+
+Next %sxception%s
+Stack trace:
+#0 %s
+#1 %s
+#2 %s


### PR DESCRIPTION
I'm not entirely sure about that one. It prevents us from directly printing to STDERR and instead deferring to PHP to handle that. PHP will automatically choose what to do based on ini settings like `display_errors`.

One potential downside of this approach is people using `exit` inside callbacks registered with `register_shutdown_function`. That would result in hiding the exception.

This might happen if you run the event loop from a `register_shutdown_function`. RxPHP does this in its examples to reduce the boilerplate for these. In that case our `exit(255);` here directly exits without executing any further shutdown functions.

Feedback and opinions are very welcome.