### PR TITLE
Fixing  parameter name in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ interface Promise
      *
      * If the promise is already resolved, the callback MUST be executed immediately.
      *
-     * @param callable(\Throwable|\Exception|null $exception, $value) @onResolved `$reason` shall be `null` on
+     * @param callable(\Throwable|\Exception|null $reason, $value) @onResolved `$reason` shall be `null` on
      *     success, `$value` shall be `null` on failure.
      *
      * @return mixed Return type and value are unspecified.


### PR DESCRIPTION
Slight discrepancy between the interface docs in readme and in the interface file.